### PR TITLE
Test: #27 Improve test coverage parseType@shader/type.go

### DIFF
--- a/internal/shader/testdata/array3.expected.vs
+++ b/internal/shader/testdata/array3.expected.vs
@@ -1,0 +1,25 @@
+uniform mat2 U0[4];
+
+mat2[2] F0(void);
+mat2[2] F1(void);
+
+mat2[2] F0(void) {
+	mat2 l0[2];
+	l0[0] = mat2(0);
+	l0[1] = mat2(0);
+	return l0;
+}
+
+mat2[2] F1(void) {
+	mat2 l0[2];
+	l0[0] = mat2(0);
+	l0[1] = mat2(0);
+	mat2 l1[2];
+	l1[0] = mat2(0);
+	l1[1] = mat2(0);
+	(l0)[0] = mat2(1.0);
+	l1[0] = l0[0];
+	l1[1] = l0[1];
+	(l1)[1] = mat2(2.0);
+	return l1;
+}

--- a/internal/shader/testdata/array3.go
+++ b/internal/shader/testdata/array3.go
@@ -1,0 +1,14 @@
+package main
+
+var Array [4]mat2
+
+func Foo() [2]mat2 {
+	var x [2]mat2
+	return x
+}
+
+func Bar() [2]mat2 {
+	x := [2]mat2{mat2(1)}
+	x[1] = mat2(2)
+	return x
+}

--- a/internal/shader/testdata/array4.expected.vs
+++ b/internal/shader/testdata/array4.expected.vs
@@ -1,0 +1,25 @@
+uniform mat3 U0[4];
+
+mat3[2] F0(void);
+mat3[2] F1(void);
+
+mat3[2] F0(void) {
+	mat3 l0[2];
+	l0[0] = mat3(0);
+	l0[1] = mat3(0);
+	return l0;
+}
+
+mat3[2] F1(void) {
+	mat3 l0[2];
+	l0[0] = mat3(0);
+	l0[1] = mat3(0);
+	mat3 l1[2];
+	l1[0] = mat3(0);
+	l1[1] = mat3(0);
+	(l0)[0] = mat3(1.0);
+	l1[0] = l0[0];
+	l1[1] = l0[1];
+	(l1)[1] = mat3(2.0);
+	return l1;
+}

--- a/internal/shader/testdata/array4.go
+++ b/internal/shader/testdata/array4.go
@@ -1,0 +1,14 @@
+package main
+
+var Array [4]mat3
+
+func Foo() [2]mat3 {
+	var x [2]mat3
+	return x
+}
+
+func Bar() [2]mat3 {
+	x := [2]mat3{mat3(1)}
+	x[1] = mat3(2)
+	return x
+}

--- a/internal/shader/testdata/array5.expected.vs
+++ b/internal/shader/testdata/array5.expected.vs
@@ -1,0 +1,25 @@
+uniform mat4 U0[4];
+
+mat4[2] F0(void);
+mat4[2] F1(void);
+
+mat4[2] F0(void) {
+	mat4 l0[2];
+	l0[0] = mat4(0);
+	l0[1] = mat4(0);
+	return l0;
+}
+
+mat4[2] F1(void) {
+	mat4 l0[2];
+	l0[0] = mat4(0);
+	l0[1] = mat4(0);
+	mat4 l1[2];
+	l1[0] = mat4(0);
+	l1[1] = mat4(0);
+	(l0)[0] = mat4(1.0);
+	l1[0] = l0[0];
+	l1[1] = l0[1];
+	(l1)[1] = mat4(2.0);
+	return l1;
+}

--- a/internal/shader/testdata/array5.go
+++ b/internal/shader/testdata/array5.go
@@ -1,0 +1,14 @@
+package main
+
+var Array [4]mat4
+
+func Foo() [2]mat4 {
+	var x [2]mat4
+	return x
+}
+
+func Bar() [2]mat4 {
+	x := [2]mat4{mat4(1)}
+	x[1] = mat4(2)
+	return x
+}


### PR DESCRIPTION
Closes #27 

Adds three new test data setups to improve branch coverage of parseType@internal/shader/type.go