### PR TITLE
24 refactor parse variable

### DIFF
--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -548,7 +548,6 @@ func (s *compileState) parseVariable(block *block, fname string, vs *ast.ValueSp
 			// No initialization
 		case len(vs.Names) == len(vs.Values):
 			// Single-value context
-			inits = append(inits)
 			es, ss, ok := s.parseSingleVariable(vs.Values[i], &t, block, fname, vs)
 			if !ok {
 				return nil, nil, nil, false

--- a/internal/shader/shader.go
+++ b/internal/shader/shader.go
@@ -445,8 +445,8 @@ func (cs *compileState) functionReturnTypes(block *block, expr ast.Expr) ([]shad
 	return nil, false
 }
 
-func (s *compileState) parseSingleVariable(i int, t shaderir.Type, block *block, fname string, vs *ast.ValueSpec) ([]shaderir.Expr, []shaderir.Stmt, bool) {
-	init := vs.Values[i]
+func (s *compileState) parseSingleVariable(init ast.Expr, t *shaderir.Type, block *block, fname string, vs *ast.ValueSpec) ([]shaderir.Expr, []shaderir.Stmt, bool) {
+	// init := vs.Values[i]
 
 	es, rts, ss, ok := s.parseExpr(block, fname, init, true)
 	if !ok {
@@ -461,7 +461,7 @@ func (s *compileState) parseSingleVariable(i int, t shaderir.Type, block *block,
 		if len(ts) > 1 {
 			s.addError(vs.Pos(), fmt.Sprintf("the numbers of lhs and rhs don't match"))
 		}
-		t = ts[0]
+		*t = ts[0]
 	}
 
 	if es[0].Type == shaderir.NumberExpr {
@@ -474,21 +474,51 @@ func (s *compileState) parseSingleVariable(i int, t shaderir.Type, block *block,
 	}
 
 	for i, rt := range rts {
-		if !canAssign(&t, &rt, es[i].Const) {
+		if !canAssign(t, &rt, es[i].Const) {
 			s.addError(vs.Pos(), fmt.Sprintf("cannot use type %s as type %s in variable declaration", rt.String(), t.String()))
 		}
 	}
 
 	return es, ss, true
-
-	// inits = append(inits, es...)
-	// stmts = append(stmts, ss...)
-
 }
 
-// func (s *compileState) parseMultipleVariable(i int) {
+func (s *compileState) parseMultipleVariable(stmts *[]shaderir.Stmt, i int, t *shaderir.Type, block *block, fname string, vs *ast.ValueSpec) ([]shaderir.Expr, bool) {
+	// These variables are used only in multiple-value context.
+	var inittypes []shaderir.Type
+	var initexprs []shaderir.Expr
+	if i == 0 {
+		init := vs.Values[0]
 
-// }
+		var ss []shaderir.Stmt
+		var ok bool
+		initexprs, inittypes, ss, ok = s.parseExpr(block, fname, init, true)
+		if !ok {
+			return nil, false
+		}
+		*stmts = append(*stmts, ss...)
+
+		if t.Main == shaderir.None {
+			ts, ok := s.functionReturnTypes(block, init)
+			if ok {
+				inittypes = ts
+			}
+			if len(ts) != len(vs.Names) {
+				s.addError(vs.Pos(), fmt.Sprintf("the numbers of lhs and rhs don't match"))
+				return initexprs, true
+			}
+		}
+	}
+
+	if t.Main == shaderir.None && len(inittypes) > 0 {
+		*t = inittypes[i]
+	}
+
+	if len(inittypes) > 0 && len(initexprs) > 0 && !canAssign(t, &inittypes[i], initexprs[i].Const) {
+		s.addError(vs.Pos(), fmt.Sprintf("cannot use type %s as type %s in variable declaration", inittypes[i].String(), t.String()))
+	}
+
+	return initexprs, true
+}
 
 func (s *compileState) parseVariable(block *block, fname string, vs *ast.ValueSpec) ([]variable, []shaderir.Expr, []shaderir.Stmt, bool) {
 	if len(vs.Names) != len(vs.Values) && len(vs.Values) != 1 && len(vs.Values) != 0 {
@@ -519,42 +549,17 @@ func (s *compileState) parseVariable(block *block, fname string, vs *ast.ValueSp
 		case len(vs.Names) == len(vs.Values):
 			// Single-value context
 			inits = append(inits)
-			s.parseSingleVariable(i, t, block, fname, vs)
+			es, ss, ok := s.parseSingleVariable(vs.Values[i], &t, block, fname, vs)
+			if !ok {
+				return nil, nil, nil, false
+			}
+			inits = append(inits, es...)
+			stmts = append(stmts, ss...)
 		default:
 			// Multiple-value context
-			// s.parseMultipleVariable(i)
-			// These variables are used only in multiple-value context.
-			var inittypes []shaderir.Type
-			var initexprs []shaderir.Expr
-			if i == 0 {
-				init := vs.Values[0]
-
-				var ss []shaderir.Stmt
-				var ok bool
-				initexprs, inittypes, ss, ok = s.parseExpr(block, fname, init, true)
-				if !ok {
-					return nil, nil, nil, false
-				}
-				stmts = append(stmts, ss...)
-
-				if t.Main == shaderir.None {
-					ts, ok := s.functionReturnTypes(block, init)
-					if ok {
-						inittypes = ts
-					}
-					if len(ts) != len(vs.Names) {
-						s.addError(vs.Pos(), fmt.Sprintf("the numbers of lhs and rhs don't match"))
-						continue
-					}
-				}
-			}
-
-			if t.Main == shaderir.None && len(inittypes) > 0 {
-				t = inittypes[i]
-			}
-
-			if !canAssign(&t, &inittypes[i], initexprs[i].Const) {
-				s.addError(vs.Pos(), fmt.Sprintf("cannot use type %s as type %s in variable declaration", inittypes[i].String(), t.String()))
+			initexprs, ok := s.parseMultipleVariable(&stmts, i, &t, block, fname, vs)
+			if !ok {
+				return nil, nil, nil, false
 			}
 
 			// Add the same initexprs for each variable.


### PR DESCRIPTION
Split two large chunks of parseVariable into separate functions, decreasing CCN from 30 to 15 (a 50% decrease).

The CCN for the new functions, parseSingleVariable and parseMultipleVariable, have a CCN of 10 and 11 respectively. The reason the summed CCN of the 3 functions is increased is due to extra error checks when returning. 

Closes issue #24.